### PR TITLE
Add albumartist slot to TRACK and export accessor

### DIFF
--- a/classes.lisp
+++ b/classes.lisp
@@ -42,6 +42,8 @@
     :initform nil :initarg :title :accessor title)
    (artist
     :initform nil :initarg :artist :accessor artist)
+   (albumartist
+    :initform nil :initarg :albumartist :accessor albumartist)
    (album
     :initform nil :initarg :album :accessor album)
    (genre

--- a/package.lisp
+++ b/package.lisp
@@ -71,6 +71,7 @@
    #:file
    #:title
    #:artist
+   #:albumartist
    #:album
    #:date
    #:duration


### PR DESCRIPTION
While experimenting with MPD I noticed that the 'album artist' tag was not supported, so I added the slot accordingly.
Kind regards
flpa
