### PR TITLE
Add slots to STATUS class and export readers.

### DIFF
--- a/classes.lisp
+++ b/classes.lisp
@@ -94,7 +94,19 @@
     :reader duration :initarg :time :initform nil)
    (songid
     :reader songid :initarg :songid :initform nil)
-   (song :reader song :initarg :song :initform nil)))
+   (song :reader song :initarg :song :initform nil)
+   (nextsongid
+    :reader nextsongid :initarg :nextsongid :initform nil)
+   (nextsong 
+    :reader nextsong :initarg :nextsong :initform nil)
+   (elapsed
+    :reader elapsed :initarg :elapsed :initform nil)
+   (mixrampdb 
+    :reader mixrampdb :initarg :mixrampdb :initform nil)
+   (consume 
+    :reader consume :initarg :consume :initform nil)
+   (single 
+    :reader single :initarg :single :initform nil)))
 
 (defclass stats ()
   ((artists

--- a/package.lisp
+++ b/package.lisp
@@ -104,6 +104,12 @@
    #:duration
    #:songid
    #:song
+   #:nextsongid
+   #:nextsong
+   #:elapsed
+   #:mixrampdb
+   #:consume
+   #:single
 
    #:artists
    #:albums


### PR DESCRIPTION
New slots: NEXTSONGID, NEXTSONG, ELAPSED, MIXRAMPDB, CONSUME, SINGLE.

Since an error is signalled when MPD encounters unknown parameters, I had to add these in order to successfully use the STATUS command in my environment.
Maintenance work (such as updating the value of the internal parameter _integer-keys_?) have not been done yet.
