### PR TITLE
check-args in list-metadata to escape spaces

### DIFF
--- a/commands.lisp
+++ b/commands.lisp
@@ -251,6 +251,7 @@
   "List all metadata of `metadata-1'.
 If `metadata-2' & `search-term' are supplied,
 then list all `metadata-1' in which `metadata-2' has value `search-term'."
+  (check-args string search-term)
   (send "list" metadata-1 metadata-2 search-term))
 
 (defcommand search-tracks (type what)


### PR DESCRIPTION
Without this, search for metadata with search terms containing spaces caused errors.
