### PR TITLE
list-metadata: only check search-term if supplied

### DIFF
--- a/commands.lisp
+++ b/commands.lisp
@@ -251,7 +251,8 @@
   "List all metadata of `metadata-1'.
 If `metadata-2' & `search-term' are supplied,
 then list all `metadata-1' in which `metadata-2' has value `search-term'."
-  (check-args string search-term)
+  (when search-term
+    (check-args string search-term))
   (send "list" metadata-1 metadata-2 search-term))
 
 (defcommand search-tracks (type what)


### PR DESCRIPTION
Unfortunately, my previous commit caused errors when invoking list-metadata without
supplying a search-term.
